### PR TITLE
fix(pdf-export): correct bidirectional text alignment for mixed Arabi…

### DIFF
--- a/src/lib/ExportToPDF.ts
+++ b/src/lib/ExportToPDF.ts
@@ -25,36 +25,45 @@ export const ExportToPDF = (editor: Editor ) => {
       }
       body {
         font-family: 'Tajawal', sans-serif;
-      }
-      ul,
-      ol {
+        /* Default to RTL matching the editor's configured default.
+           Elements with an explicit dir attribute override this. */
         direction: rtl;
       }
-     img {
+      [dir="rtl"] {
+        direction: rtl;
+        text-align: right;
+      }
+      [dir="ltr"] {
+        direction: ltr;
+        text-align: left;
+      }
+      img {
         display: block;
         max-width: fit-content;
         height: auto;
-        margin-left: auto;
-        margin-right: auto;
+        margin-inline: auto;
       }
       blockquote {
-        border-inline-end: 3px solid #618ee7; /* RTL/LTR friendly */
-        border-inline-start: none;
+        /* border-inline-start = left in LTR, right in RTL — no hardcoding needed */
+        border-inline-start: 3px solid #618ee7;
+        border-inline-end: none;
         background: rgb(243, 244, 246);
         color: #5a5a5a;
-        padding-top: 20;
-        padding-bottom: 20;
-        padding-right: 10px;
+        padding-top: 20px;
+        padding-bottom: 20px;
+        /* padding-inline-start flips automatically with dir */
+        padding-inline-start: 10px;
       }
 
       /* Center tables on the page, keep them responsive */
       table {
         border-collapse: collapse;
-        width: 90%;            /* size to content */
-        table-layout: auto;    /* natural column sizing */
-        margin: 1em 0;      /* center horizontally */
+        width: 90%;
+        table-layout: auto;
+        margin-block: 1em;
+        margin-inline: auto; /* centers the table regardless of direction */
         background: transparent;
-        display: table;        /* ensure it's treated like a table */
+        display: table;
       }
 
       table th,
@@ -62,7 +71,7 @@ export const ExportToPDF = (editor: Editor ) => {
         border: none;
         border-bottom: 1px solid #e5e7eb;
         padding: 8px 12px;
-        text-align: right;     /* keep RTL cell alignment */
+        /* inherits text-align from [dir] rules above */
         vertical-align: middle;
       }
 


### PR DESCRIPTION
# fix(pdf-export): correct bidirectional text alignment for mixed Arabic/English content

## Introduction 

Hello this is Mohammed Saad 👋,

I just wanted to say that I really like your product and the vision behind Dawin Editor. It’s inspiring to see an Arabic-first Markdown editor built with such attention to simplicity, usability, and modern design. The live preview, offline support, and smooth RTL experience make it feel thoughtful and polished.

## Problem

When exporting a document to PDF that contained English content (paragraphs, bullet lists, blockquotes), all elements were incorrectly right-aligned. Arabic content was unaffected.

**Root cause:** `ExportToPDF.ts` injected a global print stylesheet with physical, direction-hardcoded CSS rules that overrode the `dir` HTML attribute that TipTap's `TextDirection` extension correctly sets on every block element (e.g. `<ul dir="ltr">`, `<p dir="rtl">`).

---

## Changes — `src/lib/ExportToPDF.ts`

### 1. Lists — replaced hardcoded `direction: rtl` with `[dir]` attribute selectors

**Before:**
```css
ul, ol {
  direction: rtl;
}
```

**After:**
```css
[dir="rtl"] { direction: rtl; text-align: right; }
[dir="ltr"] { direction: ltr; text-align: left; }
```

The `TextDirection` extension already writes `dir="ltr"` / `dir="rtl"` on every block node. The old rule was silently overriding it for all lists regardless of language.

---

### 2. Blockquote — switched to CSS logical properties

**Before:**
```css
blockquote {
  border-inline-end: 3px solid #618ee7; /* wrong side for LTR */
  border-inline-start: none;
  padding-top: 20;       /* missing px unit */
  padding-bottom: 20;    /* missing px unit */
  padding-right: 10px;   /* hardcoded physical direction */
}
```

**After:**
```css
blockquote {
  border-inline-start: 3px solid #618ee7; /* left in LTR, right in RTL */
  border-inline-end: none;
  padding-top: 20px;
  padding-bottom: 20px;
  padding-inline-start: 10px; /* flips automatically with dir */
}
```

- The accent border was on the wrong side (`inline-end`) — it now uses `inline-start`, which is the conventional "left rail" in LTR and "right rail" in RTL.
- `padding-top/bottom` were missing the `px` unit (treated as `0` in print context).
- `padding-right` replaced with the logical `padding-inline-start`.

---

### 3. `body` — added RTL direction default

```css
body {
  direction: rtl; /* matches the editor's configured default */
}
```

`printJS` wraps printed HTML in a plain `<body>` with no `dir` attribute. Without this, top-level RTL blocks that happen to lack an explicit `dir` attribute would fall back to the browser's LTR default.

---

### 4. `img` — replaced physical margins with logical equivalent

```css
/* Before */
margin-left: auto;
margin-right: auto;

/* After */
margin-inline: auto;
```

---

### 5. `table` — fixed inline margin so tables are centered in both directions

```css
/* Before */
margin: 1em 0; /* 0 on inline axis = left-aligned in LTR */

/* After */
margin-block: 1em;
margin-inline: auto; /* centered regardless of direction */
```

---

### 6. `table th / td` — removed hardcoded `text-align: right`

```css
/* Before */
text-align: right;

/* After — inherits from [dir] rules */
```

---

## Design principle

All fixes follow the same strategy: **use CSS logical properties and `[dir]` attribute selectors instead of hardcoded physical directions.** This delegates layout decisions to the `dir` attribute that TipTap's `TextDirection` extension already manages correctly, making the PDF output a faithful reflection of what the user sees in the editor.
